### PR TITLE
removed createOutputFolder() since folders are created automatically …

### DIFF
--- a/src/platform/node/engines/dot.ts
+++ b/src/platform/node/engines/dot.ts
@@ -135,7 +135,6 @@ digraph dependencies {
 				png: path.join(this.cwd, `${ this.options.output }/dependencies.png`),
 				html: path.join(this.cwd, `${ this.options.output }/dependencies.html`)
 			};
-			this.createOutputFolders(this.options.output);
 		}
 
 		generateGraph(deps) {
@@ -146,12 +145,6 @@ digraph dependencies {
 				.then( _ => this.generateSVG() )
 				.then( _ => this.generateHTML() )
 				//.then( _ => this.generatePNG() );
-		}
-
-		private createOutputFolders(output) {
-			Object.keys(output).forEach( (prop) => {
-				return fs.mkdirpSync(path.join(this.cwd, `../../${ output[prop] }`));
-			});
 		}
 
 		private preprocessTemplates(options?) {


### PR DESCRIPTION
…by fs.outputFile()

The function I deleted iterates over the `output` string (by default "documentation/angular2-dependencies-graph") and creates a folder for each character (hence the behavior described in [#5](https://github.com/manekinekko/angular2-dependencies-graph/issues/5)). 

I deleted the function because creating a output folder is not necessary: the function `fs.outputFile()`, which is used to create the files, creates the folders (defined in `this.paths`) automatically if they don't exist already. See [node-fs-extra](https://github.com/jprichardson/node-fs-extra#outputfilefile-data-options-callback).